### PR TITLE
feat: add captured unit to party

### DIFF
--- a/Assets/Events/UnitAddedToParty.asset
+++ b/Assets/Events/UnitAddedToParty.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58a02151afb7c5f4f9611e09420c68d6, type: 3}
+  m_Name: UnitAddedToParty
+  m_EditorClassIdentifier: 

--- a/Assets/Events/UnitAddedToParty.asset.meta
+++ b/Assets/Events/UnitAddedToParty.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ee01b4410365b041b09beeb57de1306
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Party/CurrentParty.asset
+++ b/Assets/Objects/Party/CurrentParty.asset
@@ -17,5 +17,8 @@ MonoBehaviour:
     profile: {fileID: 11400000, guid: e7ad7445ab8bff641bc4bf678a2840ef, type: 2}
     hasBeenCreated: 0
   - unit: {fileID: 0}
-    profile: {fileID: 11400000, guid: fc7da072d0b1a20429a8dfdce42a2f39, type: 2}
+    profile: {fileID: 0}
+    hasBeenCreated: 0
+  - unit: {fileID: 0}
+    profile: {fileID: 0}
     hasBeenCreated: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -534,6 +534,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 1894465637}
     m_Modifications:
     - target: {fileID: 8894169554421551678, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: AddedToParty
+      value: 
+      objectReference: {fileID: 11400000, guid: 3ee01b4410365b041b09beeb57de1306, type: 2}
+    - target: {fileID: 8894169554421551678, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
       propertyPath: currentParty
       value: 
       objectReference: {fileID: 11400000, guid: 16f87b819b7da344b897b3fc9f583818, type: 2}
@@ -871,7 +875,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 122.1, y: -135}
+  m_AnchoredPosition: {x: 187, y: -135}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &693304064
@@ -1480,6 +1484,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   TowerTemplate: {fileID: 4656894821810783984, guid: 2ff6b753a129588428dc854d277c4939, type: 3}
   currentParty: {fileID: 11400000, guid: 16f87b819b7da344b897b3fc9f583818, type: 2}
+  AddedToParty: {fileID: 11400000, guid: 3ee01b4410365b041b09beeb57de1306, type: 2}
+  UnitCapturedEvent: {fileID: 11400000, guid: f77cec3988eae6745b00a667a21340a9, type: 2}
 --- !u!4 &1294913648
 Transform:
   m_ObjectHideFlags: 0
@@ -1574,6 +1580,120 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3697870bf7cedc941a392238f8d823d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1405396975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1894465637}
+    m_Modifications:
+    - target: {fileID: 8894169554421551678, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: AddedToParty
+      value: 
+      objectReference: {fileID: 11400000, guid: 3ee01b4410365b041b09beeb57de1306, type: 2}
+    - target: {fileID: 8894169554421551678, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: currentParty
+      value: 
+      objectReference: {fileID: 11400000, guid: 16f87b819b7da344b897b3fc9f583818, type: 2}
+    - target: {fileID: 8894169554421551678, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: partyPosition
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127785, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_Name
+      value: TowerBtn3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -116
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+--- !u!224 &1405396976 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8894169555686127798, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+  m_PrefabInstance: {fileID: 1405396975}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1505621329
 GameObject:
   m_ObjectHideFlags: 0
@@ -1757,6 +1877,7 @@ RectTransform:
   - {fileID: 905346000}
   - {fileID: 453728908}
   - {fileID: 314028060}
+  - {fileID: 1405396976}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2018,6 +2139,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1894465637}
     m_Modifications:
+    - target: {fileID: 8894169554421551678, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
+      propertyPath: AddedToParty
+      value: 
+      objectReference: {fileID: 11400000, guid: 3ee01b4410365b041b09beeb57de1306, type: 2}
     - target: {fileID: 8894169554421551678, guid: c4873ef2a2487d341ba446da8610b93a, type: 3}
       propertyPath: currentParty
       value: 

--- a/Assets/Scripts/Level/PartyManager.cs
+++ b/Assets/Scripts/Level/PartyManager.cs
@@ -6,9 +6,12 @@ public class PartyManager : MonoBehaviour
 {
     public GameObject TowerTemplate;
     public UnitParty currentParty;
+    public IntEvent AddedToParty;
+    public UnitEvent UnitCapturedEvent;
     // Start is called before the first frame update
     void Start()
     {
+        UnitCapturedEvent.RegisterListener(onUnitCaptured);
         init();
     }
 
@@ -19,11 +22,54 @@ public class PartyManager : MonoBehaviour
        for(var i=0; i < currentParty.party.Count; i++) {
             var container = currentParty.party[i];
             if (container.unit) Destroy(container.unit);
+            if (container.profile == null) continue; // skip if we have no profile on this spot
             container.unit = CreateTower(container.profile, i);
             container.hasBeenCreated = true;
        }
 
        Debug.Log("party initialized");
+    }
+
+    // Called when a unit is captured, will try to add to party
+    public int onUnitCaptured(Unit unit) {
+
+        // Hardcoding this for now, later will extract from actual unit
+        var newProfile = new UnitProfile();
+        newProfile.unitID = 20;
+        newProfile.nickname = "Ratty";
+        newProfile.attack1ID = AttackID.BASIC_PROJECTILE;
+        newProfile.lvl = 1;
+        newProfile.baseHP = 10;
+        newProfile.baseSpeed = 7;
+        // Try to add to our party
+        addCapturedUnitToParty(newProfile);
+        return 0;
+    }
+
+
+    private void addCapturedUnitToParty(UnitProfile profile) {
+       // Check to see if we have space in our party
+       var emptySpot = getEmptySpotInParty();
+       if (emptySpot == -1) {
+           Debug.Log("No space in party for new unit");
+           return;
+       }
+       // Create a new unit and add it to our party
+       var container = currentParty.party[emptySpot];
+       container.profile = profile;
+       container.unit = CreateTower(profile, emptySpot);
+       container.hasBeenCreated = true;
+
+       // Send event that we have added to party
+       AddedToParty.Raise(emptySpot);
+    }
+
+    private int getEmptySpotInParty() {
+        for(var i=0; i < currentParty.party.Count; i++) {
+            var container = currentParty.party[i];
+            if (container.hasBeenCreated == false) return i;
+        }
+        return -1;
     }
 
     // Create unit from a profile

--- a/Assets/Scripts/UI/TowerBtn.cs
+++ b/Assets/Scripts/UI/TowerBtn.cs
@@ -13,35 +13,53 @@ public class TowerBtn : MonoBehaviour, IPointerDownHandler, IBeginDragHandler, I
     public UnitProfile currentProfile;
     public GameObject unitGfxContainer;
     public bool isEmpty;
+    public IntEvent AddedToParty;
 
     private void Start() {
+        AddedToParty.RegisterListener(onAddedToParty);
         init();
     }
 
     public void init()  {
         //Use party position to init our graphic and nickname
-        isEmpty = true;
         if (currentParty.party != null && partyPosition < currentParty.party.Count) {
             currentProfile = currentParty.party[partyPosition].profile; // Grab profile from our party object
-            isEmpty = false;
-            UnitNickName.text = currentProfile.nickname; // Assign unit's nickname to button text
-            UIUtil.setUnitGfx(currentProfile.unitID, unitGfxContainer.transform); // Set Button Unit Graphic
+            if (currentProfile == null) {
+                isEmpty = true;
+                UnitNickName.text = "Empty";
+            }else{
+                isEmpty = false;
+                UnitNickName.text = currentProfile.nickname; // Assign unit's nickname to button text
+                UIUtil.setUnitGfx(currentProfile.unitID, unitGfxContainer.transform); // Set Button Unit Graphic
+            }
         }
+    }
+
+    // Called when a unit is added to the party mid level
+    public int onAddedToParty(int partyIndex) {
+        // If we are empty and we added a unit here then init our graphic and nickname
+        if (isEmpty && partyIndex == partyPosition) {
+            init();
+        }
+        return 0;
     }
 
     public void OnPointerDown(PointerEventData eventData) {
     }
 
     public void OnEndDrag(PointerEventData eventData) {
+        if (isEmpty) return; // don't do it if we are empty
         //Stop Dragging the tower
         EndTowerDrag.Raise();
     }
 
     public void OnBeginDrag(PointerEventData eventData) {
+        if (isEmpty) return; // don't do it if we are empty
         StartTowerDrag.Raise(partyPosition); // Start dragging the tower
     }
 
     public void OnDrag(PointerEventData eventData) {
+        if (isEmpty) return; // don't do it if we are empty
         //Drag the tower
         DoTowerDrag.Raise();
     }


### PR DESCRIPTION
Implementation for adding a captured unit to your party and updating the UI allowing you to use it in combat.

For now the unit profile added is hardcoded to be a rat but will change in the future to reflect actual enemy unit.

Resolves #11 